### PR TITLE
csl-deckListFeedAndMyDeckList

### DIFF
--- a/src/components/ApplicationViews.js
+++ b/src/components/ApplicationViews.js
@@ -1,5 +1,7 @@
 import React from "react"
 import {Route} from "react-router-dom"
+import { DeckList } from "./deck/DeckList"
+import { MyDecks } from "./deck/MyDecks"
 import {Home} from "./home/home"
 export const ApplicationViews = () => {
     return <>
@@ -9,6 +11,12 @@ export const ApplicationViews = () => {
     }}>
         <Route exact path="/">
             <Home />
+        </Route>
+        <Route exact path="/deckfeed">
+            <DeckList />
+        </Route>
+        <Route exact path="/MyDeckList">
+            <MyDecks />
         </Route>
     </main>
     </>

--- a/src/components/auth/Login.js
+++ b/src/components/auth/Login.js
@@ -27,6 +27,8 @@ export const Login = () => {
             .then(res => {
                 if ("valid" in res && res.valid && "token" in res) {
                     localStorage.setItem("ss_token", res.token)
+                    //added line below to store the playerId in local storage so we can reference to get the current user 
+                    localStorage.set("playerId", res.id)
                     history.push("/")
                 }
                 else {
@@ -46,7 +48,7 @@ export const Login = () => {
                     <h1>Sylvan Serving</h1>
                     <h2>Please sign in</h2>
                     <fieldset>
-                        <label htmlFor="inputUsername"> Username address </label>
+                        <label htmlFor="inputUsername"> Username </label>
                         <input ref={username} type="username" id="username" className="form-control" placeholder="Username address" required autoFocus />
                     </fieldset>
                     <fieldset>

--- a/src/components/auth/Register.js
+++ b/src/components/auth/Register.js
@@ -36,6 +36,8 @@ export const Register = () => {
                 .then(res => {
                     if ("token" in res) {
                         localStorage.setItem("ss_token", res.token)
+                        //added line below to store the playerId in local storage so we can reference to get the current user 
+                        localStorage.setItem("playerId", res.id)
                         history.push("/")
                     }
                 })

--- a/src/components/deck/DeckList.js
+++ b/src/components/deck/DeckList.js
@@ -1,0 +1,35 @@
+import React, { useEffect, useState } from "react"
+import { useHistory } from 'react-router-dom'
+import { getDecks } from "./DeckManager"
+
+export const DeckList = (props) => {
+    const [decks, setDecks] = useState([])
+  
+
+    const history = useHistory()
+    useEffect(() => {
+        getDecks().then(data => setDecks(data))
+    }, [])
+
+    return (
+        <>
+            <button className="btn btn-2 btn-sep icon-create"
+                onClick={() => {
+                    history.push({ pathname: "/decks/new" })
+                }}
+            >Create New Deck List</button>
+            <article className="decks">
+                {
+                    decks.map(deck => {
+                        return <section key={`deck--${deck.id}`} className="deck">
+                            <div className="deck__title">{deck.title} by {deck.player?.user.username}</div>
+                            <div className="playStyle">Play style: {deck.playStyle.label}</div>
+                            <img className="commander_image" src={deck.commander} alt="commander_image" />
+                            
+                        </section>
+                    })
+                }
+            </article>
+        </>
+    )
+}

--- a/src/components/deck/DeckManager.js
+++ b/src/components/deck/DeckManager.js
@@ -1,0 +1,78 @@
+export const getDecks = () => {
+    return fetch("http://localhost:8000/decks", {
+        headers:{
+            "Authorization": `Token ${localStorage.getItem("ss_token")}`
+        }
+    })
+        .then(response => response.json())
+}
+
+export const getDeck= (id) => {
+    return fetch(`http://localhost:8000/decks/${id}`, {
+        headers: {
+            "Authorization": `Token ${localStorage.getItem("ss_token")}`
+        }
+    })
+        .then(response => response.json())
+}
+
+export const createDeck = (deck) => {
+    return fetch("http://localhost:8000/decks", {
+        method: "POST",
+        headers: {
+            "Authorization": `Token ${localStorage.getItem("ss_token")}`,
+            "Content-Type": "application/json"
+        },
+        body: JSON.stringify(deck)
+
+    })
+        .then(getDecks)
+}
+
+export const getPlayStyle = () => {
+    return fetch("http://localhost:8000/playStyle", {
+        headers:{
+            "Authorization": `Token ${localStorage.getItem("ss_token")}`
+        }
+     })
+        .then(response => response.json())
+}
+
+export const updateDeck = (id, deck) => {
+    return fetch(`http://localhost:8000/decks/${id}`, {
+        method: "PUT",
+        headers: {
+            "Authorization": `Token ${localStorage.getItem("ss_token")}`,
+            "Content-Type": "application/json"
+        },
+        body: JSON.stringify(deck)
+
+    })
+        .then(getDecks)
+}
+
+export const deleteDeck = (id) => {
+    return fetch(`http://localhost:8000/decks/${id}`, {
+        method: "DELETE",
+        headers: {
+            "Authorization": `Token ${localStorage.getItem("ss_token")}`
+        }
+    })
+        .then(getDecks)
+}
+
+export const getDeckById = (deckId) => {
+	return fetch(`http://localhost:8000/decks/${deckId}`, {
+		headers: {
+			Authorization: `Token ${localStorage.getItem("ss_token")}`,
+		},
+	}).then((res) => res.json())
+}
+
+export const getDeckByCurrentPlayer = (playerId) => {
+	return fetch(`http://localhost:8000/decks?playerId=${playerId}`, {
+		headers: {
+			Authorization: `Token ${localStorage.getItem('ss_token')}`,
+		}
+	}).then((res) => res.json())
+  }

--- a/src/components/deck/MyDecks.js
+++ b/src/components/deck/MyDecks.js
@@ -1,0 +1,75 @@
+import React, { useEffect, useState } from "react"
+import { getDeckByCurrentPlayer } from "./DeckManager"
+import { Link } from "react-router-dom"
+import { getThisPlayer } from "../players/playerManager"
+
+
+
+
+export const MyDecks = () => {
+//declaring useState for decks and currentPlayer 
+	const [currentPlayer, setCurrentPlayer] = useState({})
+    const [isLoading, setIsLoading] = useState(true)
+    const [foundDeck, setFoundDeck] = useState([])
+
+
+
+	useEffect(() => {
+        
+		const playerId = localStorage["playerId"]
+        
+		getThisPlayer(playerId).then((player) => {
+            setIsLoading(false)
+			setCurrentPlayer(player)
+		})
+	}, [])
+
+	useEffect(() => {
+		// Query string parameter
+        if (currentPlayer.id) {
+		const playerId = currentPlayer.id
+		getDeckByCurrentPlayer(playerId).then((deck) => {
+            // setDeck(deck)
+            setIsLoading(false)
+			setFoundDeck(deck.filter(deck1 => deck1["player"]["id"] === parseInt(playerId)))
+		})}
+	}, [currentPlayer])
+	
+if(isLoading) return <>Loading data...</>
+
+    return (
+        //  <> Fragment puts all return elements into one JXS element 
+        <>
+
+            <div className="decks"></div>
+            {
+                foundDeck.map(
+                    (completedDecks) => {
+
+                        return foundDeck ? <center>
+
+                            <div className="completedDeckList"><div key={`completedDecks.id-${completedDecks.id}`}>
+                             <Link to={`/decks/${completedDecks.id}`}>{completedDecks.title} </Link>
+                             <div className="deckAuthor">by {completedDecks.player?.user.username}</div> 
+                            <div className="playStyle">Play style: {completedDecks.playStyle.label}</div>
+                            <img className="commander_image" src={completedDecks.commander} alt="commander_image" />
+                            <div className="deckList">Creatures: {completedDecks.creatures}</div>
+                            <div className="deckList">Artifacts: {completedDecks.artifacts}</div>
+                            <div className="deckList">Enchantments: {completedDecks.enchantments}</div>
+                            <div className="deckList">Instants: {completedDecks.instants}</div>
+                            <div className="deckList">Sorceries: {completedDecks.sorceries}</div>
+                            <div className="deckList">Lands: {completedDecks.lands}</div>
+                            <div className="deckList">Wins: {completedDecks.wins}</div>
+                            <div className="deckList">Losses: {completedDecks.losses}</div>
+                            <div className="deckList">Power Level: {completedDecks.powerLevel}</div>
+                            <div className="deckList">Primer: {completedDecks.primer}</div>
+                            </div>
+                            </div>
+                        </center>
+                        : <div> none </div>
+                    } 
+                )
+            }
+        </>
+    )
+}

--- a/src/components/nav/NavBar.js
+++ b/src/components/nav/NavBar.js
@@ -16,7 +16,7 @@ export const NavBar = () => {
                 <Link className="navbar_item" to="/events">Events</Link>
             </li>
             <li className="navbar__item">
-                <Link className="navbar_item" to="/mydecks">My Decks</Link>
+                <Link className="navbar_item" to="/MyDeckList">My Decks</Link>
             </li>
             <li className="navbar__item">
                 <Link className="navbar_item" to="/info">Rules And Info</Link>
@@ -24,14 +24,14 @@ export const NavBar = () => {
             
             {
                 (localStorage.getItem("ss_token") !== null) ?
-                    <li className="nav-item">
+                    
                         <button className="nav-link fakeLink"
                             onClick={() => {
                                 localStorage.removeItem("ss_token")
                                 history.push({ pathname: "/" })
                             }}
                         >Logout</button>
-                    </li> :
+                     :
                     <>
                         <li className="nav-item">
                             <Link className="nav-link" to="/login">Login</Link>

--- a/src/components/players/playerManager.js
+++ b/src/components/players/playerManager.js
@@ -1,0 +1,24 @@
+export const getThisPlayer = (playerId) => {
+	return fetch(`http://localhost:8000/players/${playerId}`, {
+    headers: {
+        Authorization: `Token ${localStorage.getItem("ss_token")}`,
+    },
+}).then((res) => res.json())
+}
+
+
+export const getPlayers= () => {
+	return fetch("http://localhost:8000/players", {
+		headers: {
+			Authorization: `Token ${localStorage.getItem("ss_token")}`,
+		},
+	}).then((res) => res.json())
+}
+
+export const getPlayerById = (playerId) => {
+	return fetch(`http://localhost:8000/players/${playerId}`, {
+		headers: {
+			Authorization: `Token ${localStorage.getItem("ss_token")}`,
+		},
+	}).then((res) => res.json())
+}


### PR DESCRIPTION
Issue: #21 Users should be able to view a list of all of the decks they created when they click on the My Decks tab of the Nav bar
Issue: #2 Navbar Functionality (continued)
Issue: #9 Users should be able to view a list of all users' submitted deck lists when they click on the Deck List Feed tab of the 
               Nav bar

Additional: Removed the bullet point from before the logout button, took off Address from Username Address that was rendering on the login/register views

Comments: Initially was having issues getting only the current user's decks rendering in the MyDeck page view even after I was successfully getting the current user. Realized that I needed to filter either on the client or server side. 

My working solution:
	// needed to check if the currentPlayer.id existed so that I could pass in playerId 
        //on the line below without it being undefined since when the state is initially set it is undefined
        if (currentPlayer.id) {
		const playerId = currentPlayer.id
		getDeckByCurrentPlayer(playerId).then((deck) => {
            setIsLoading(false)
			setFoundDeck(deck.filter(deck1 => deck1["player"]["id"] === parseInt(playerId)))
		})}
	}, [currentPlayer])

Created files:
MyDecks.js
DeckList.js 
DeckListManager.js
playerManager.js

Modified files:
ApplicationViews.js
Login.js 
Register.js 
Navbar.js

Expected: 
1. When a new user is registered and logs in then their playerId should be stored and accessible from localstorage 
2. When a logged in user clicks on the Deck List Feed tab then all decks created by all users should render in a list on 
    the page
3. When a logged in user clicks on the My Decks tab of the navbar then all of the decks created by the currently logged in user 
    should render on the page  