### PR TITLE
csl-DeckForm

### DIFF
--- a/src/components/ApplicationViews.js
+++ b/src/components/ApplicationViews.js
@@ -1,5 +1,6 @@
 import React from "react"
 import {Route} from "react-router-dom"
+import { DeckForm } from "./deck/DeckForm"
 import { DeckList } from "./deck/DeckList"
 import { MyDecks } from "./deck/MyDecks"
 import {Home} from "./home/home"
@@ -17,6 +18,12 @@ export const ApplicationViews = () => {
         </Route>
         <Route exact path="/MyDeckList">
             <MyDecks />
+        </Route>
+        <Route exact path="/decks/new">
+            <DeckForm />
+        </Route>
+        <Route exact path="/decks/edit/:deckId(\d+)">
+            <DeckForm editDeck = {true}/>
         </Route>
     </main>
     </>

--- a/src/components/deck/DeckForm.js
+++ b/src/components/deck/DeckForm.js
@@ -1,0 +1,279 @@
+import React, { useState, useEffect } from "react"
+import { useHistory } from "react-router-dom"
+import { useParams } from "react-router-dom/cjs/react-router-dom.min"
+import { createDeck, getDeckById, getPlayStyle, updateDeck } from "./DeckManager"
+
+
+
+export const DeckForm = ({ editDeck }) => {
+    // const [player, setCurrentPlayer] = useState()
+    const history = useHistory()
+    const [playStyle, setPlayStyle] = useState([])
+    const { deckId } = useParams()
+    const [currentDeck, setDeck] = useState({
+        player: "",
+        playStyle: "",
+        title: "",
+        commander: "",
+        creatures: "",
+        artifacts: "",
+        enchantments: "",
+        instants: "",
+        sorceries: "",
+        lands: "",
+        wins: "",
+        losses: "",
+        powerLevel: "",
+        primer: ""
+    })
+
+
+    useEffect(() => {
+        if (deckId) {
+            getDeckById(deckId).then((res) => {
+                const deckEdit = {
+                    playStyle: res.playStyle,
+                    title: res.title,
+                    commander: res.commander,
+                    creatures: res.creatures,
+                    artifacts: res.artifacts,
+                    enchantments: res.enchantments,
+                    instants: res.instants,
+                    sorceries: res.sorceries,
+                    lands: res.lands,
+                    wins: res.wins,
+                    losses: res.losses,
+                    powerLevel: res.powerLevel,
+                    primer: res.primer
+                }
+                setDeck(deckEdit)
+            })
+        }
+    }, [deckId])
+    
+    useEffect(() => {
+        getPlayStyle().then(setPlayStyle)
+    }, [])
+
+    const changeDeckState = (event) => {
+        const copy = { ...currentDeck }
+        copy[event.target.name] = event.target.value
+
+        setDeck(copy)
+    }
+
+    return (
+        <form className="deckForm">
+            <h2 className="deckFormTitle">New Deck List</h2>
+            <fieldset>
+                <div className="form-group">
+                    <label htmlFor="title" >Deck Title: </label>
+                    <input
+                        value={currentDeck.title}
+                        onChange={changeDeckState}
+                        required autoFocus
+                        type="text"
+                        className="form-control"
+                        placeholder="Name your deck!"
+                        name="title"
+                    />
+                </div>
+            </fieldset>
+            <fieldset>
+                <div className="form-group">
+                    <label htmlFor="playStyle">Play Style: </label>
+                    <select type="number" name="playStyle" required autoFocus className="form-control"
+                        value={currentDeck.playStyle}
+                        onChange={changeDeckState}>
+                        <option value="">Select a Play Style</option>
+                        {
+                            playStyle.map((playStyle) => {
+                                return <option key={playStyle.id} value={playStyle.id}>{playStyle.label}</option>
+                            })
+                        }
+                    </select>
+                </div>
+            </fieldset>
+            <fieldset>
+                <div className="form-group">
+                    <label htmlFor="commander" >Who is your Commander?: </label>
+                    <input
+                        value={currentDeck.commander}
+                        onChange={changeDeckState}
+                        required autoFocus
+                        type="url"
+                        className="form-control"
+                        placeholder="Input an image url!"
+                        name="commander"
+                    />
+                </div>
+            </fieldset>
+            <fieldset>
+                <div className="form-group">
+                    <label htmlFor="creatures" >Creatures: </label>
+                    <textarea
+                        value={currentDeck.creatures}
+                        onChange={changeDeckState}
+                        required autoFocus
+                        type="text"
+                        className="form-control"
+                        placeholder="Input your list of creatures"
+                        name="creatures"
+                    />
+                </div>
+            </fieldset>
+            <fieldset>
+                <div className="form-group">
+                    <label htmlFor="artifacts" >Artifacts: </label>
+                    <textarea
+                        value={currentDeck.artifacts}
+                        onChange={changeDeckState}
+                        required autoFocus
+                        type="text"
+                        className="form-control"
+                        placeholder="Input your list of artifacts"
+                        name="artifacts"
+                    />
+                </div>
+            </fieldset>
+            <fieldset>
+                <div className="form-group">
+                    <label htmlFor="enchantments" >Enchantments: </label>
+                    <textarea
+                        value={currentDeck.enchantments}
+                        onChange={changeDeckState}
+                        required autoFocus
+                        type="text"
+                        className="form-control"
+                        placeholder="Input your list of enchantments"
+                        name="enchantments"
+                    />
+                </div>
+            </fieldset>
+            <fieldset>
+                <div className="form-group">
+                    <label htmlFor="instants" >Instants: </label>
+                    <textarea
+                        value={currentDeck.instants}
+                        onChange={changeDeckState}
+                        required autoFocus
+                        type="text"
+                        className="form-control"
+                        placeholder="Input your list of instants"
+                        name="instants"
+                    />
+                </div>
+            </fieldset>
+            <fieldset>
+                <div className="form-group">
+                    <label htmlFor="sorceries" >Sorceries: </label>
+                    <textarea
+                        value={currentDeck.sorceries}
+                        onChange={changeDeckState}
+                        required autoFocus
+                        type="text"
+                        className="form-control"
+                        placeholder="Input your list of sorceries"
+                        name="sorceries"
+                    />
+                </div>
+            </fieldset>
+            <fieldset>
+                <div className="form-group">
+                    <label htmlFor="lands" >Lands: </label>
+                    <textarea
+                        value={currentDeck.lands}
+                        onChange={changeDeckState}
+                        required autoFocus
+                        type="text"
+                        className="form-control"
+                        placeholder="Input your list of lands"
+                        name="lands"
+                    />
+                </div>
+            </fieldset>
+            <fieldset>
+                <div className="form-group">
+                    <label htmlFor="powerLevel" max="10">Power Level: </label>
+                    <input name="powerLevel"
+                        value={currentDeck.powerLevel}
+                        onChange={changeDeckState}
+                        required autoFocus
+                        type="text"
+                        className="form-control"
+                        placeholder="What would you rank the power level of this deck?"
+                    />
+                </div>
+            </fieldset>
+            <fieldset>
+                <div className="form-group">
+                    <label htmlFor="wins" >Wins: </label>
+                    <input name="wins"
+                        value={currentDeck.wins}
+                        onChange={changeDeckState}
+                        required autoFocus
+                        type="text"
+                        className="form-control"
+                        placeholder="How many games has this deck won?"
+                    />
+                </div>
+            </fieldset>
+            <fieldset>
+                <div className="form-group">
+                    <label htmlFor="losses" >Losses: </label>
+                    <input
+                        name="losses"
+                        value={currentDeck.losses}
+                        onChange={changeDeckState}
+                        required autoFocus
+                        type="text"
+                        className="form-control"
+                        placeholder="How many games has this deck lost?"
+                    />
+                </div>
+            </fieldset>
+            <fieldset>
+                <div className="form-group">
+                    <label htmlFor="primer" >Primer: </label>
+                    <textarea
+                        value={currentDeck.primer}
+                        onChange={changeDeckState}
+                        required autoFocus
+                        type="text"
+                        className="form-control"
+                        placeholder="Describe your deck's general game plan, wincons, and synergies"
+                        name="primer"
+                        
+                    />
+                </div>
+            </fieldset>
+
+            <button type="submit"
+                onClick={evt => {
+                    evt.preventDefault()
+
+                    const deck = {
+                        playStyle: parseInt(currentDeck.playStyle),
+                        title: currentDeck.title,
+                        commander: currentDeck.commander,
+                        creatures: currentDeck.creatures,
+                        artifacts: currentDeck.artifacts,
+                        enchantments: currentDeck.enchantments,
+                        instants: currentDeck.instants,
+                        sorceries: currentDeck.sorceries,
+                        lands: currentDeck.lands,
+                        wins: parseInt(currentDeck.wins),
+                        losses: parseInt(currentDeck.losses),
+                        powerLevel: parseInt(currentDeck.powerLevel),
+                        primer: currentDeck.primer
+                    }
+                    editDeck
+                        ? updateDeck(deckId, deck)
+                            .then(() => history.push("/MyDeckList"))
+                        : createDeck(deck)
+                            .then(() => history.push("/MyDeckList"))
+                }}
+                className="btn btn-primary">{editDeck ? "Update Deck" : "Create Deck"} </button>
+        </form>
+    )
+}

--- a/src/components/deck/DeckList.js
+++ b/src/components/deck/DeckList.js
@@ -1,8 +1,9 @@
 import React, { useEffect, useState } from "react"
 import { useHistory } from 'react-router-dom'
 import { getDecks } from "./DeckManager"
+import { Link } from "react-router-dom"
 
-export const DeckList = (props) => {
+export const DeckList = () => {
     const [decks, setDecks] = useState([])
   
 
@@ -13,19 +14,21 @@ export const DeckList = (props) => {
 
     return (
         <>
-            <button className="btn btn-2 btn-sep icon-create"
+            <center><button className="btn btn-2 btn-sep icon-create"
                 onClick={() => {
                     history.push({ pathname: "/decks/new" })
                 }}
-            >Create New Deck List</button>
+            >Create New Deck List</button></center>
             <article className="decks">
                 {
                     decks.map(deck => {
                         return <section key={`deck--${deck.id}`} className="deck">
-                            <div className="deck__title">{deck.title} by {deck.player?.user.username}</div>
+                            <ol>
+                            <Link to={`/decks/${deck.id}`}>{deck.title} </Link>
+                            <div className="deckAuthor">Created by: {deck.player?.user.username}</div>
                             <div className="playStyle">Play style: {deck.playStyle.label}</div>
                             <img className="commander_image" src={deck.commander} alt="commander_image" />
-                            
+                            </ol>
                         </section>
                     })
                 }

--- a/src/components/deck/MyDecks.js
+++ b/src/components/deck/MyDecks.js
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from "react"
 import { getDeckByCurrentPlayer } from "./DeckManager"
 import { Link } from "react-router-dom"
 import { getThisPlayer } from "../players/playerManager"
-
+import "./decks.css"
 
 
 
@@ -49,22 +49,50 @@ if(isLoading) return <>Loading data...</>
                         return foundDeck ? <center>
 
                             <div className="completedDeckList"><div key={`completedDecks.id-${completedDecks.id}`}>
-                             <Link to={`/decks/${completedDecks.id}`}>{completedDecks.title} </Link>
-                             <div className="deckAuthor">by {completedDecks.player?.user.username}</div> 
+                            <Link to={`/decks/${completedDecks.id}`}>{completedDecks.title} </Link>
+                            <div className="deckAuthor">by {completedDecks.player?.user.username}</div> 
                             <div className="playStyle">Play style: {completedDecks.playStyle.label}</div>
                             <img className="commander_image" src={completedDecks.commander} alt="commander_image" />
-                            <div className="deckList">Creatures: {completedDecks.creatures}</div>
-                            <div className="deckList">Artifacts: {completedDecks.artifacts}</div>
-                            <div className="deckList">Enchantments: {completedDecks.enchantments}</div>
-                            <div className="deckList">Instants: {completedDecks.instants}</div>
-                            <div className="deckList">Sorceries: {completedDecks.sorceries}</div>
-                            <div className="deckList">Lands: {completedDecks.lands}</div>
-                            <div className="deckList">Wins: {completedDecks.wins}</div>
-                            <div className="deckList">Losses: {completedDecks.losses}</div>
-                            <div className="deckList">Power Level: {completedDecks.powerLevel}</div>
-                            <div className="deckList">Primer: {completedDecks.primer}</div>
+                            <b><div className="deckList">Creatures:</div></b>
+                            <div className="deckList1" > {completedDecks.creatures}</div>
+                            <p></p>
+                            <b><div className="deckList">Artifacts:</div></b>
+                            <div className="deckList1">{completedDecks.artifacts}</div>
+                            <p></p>
+                            <b><div className="deckList">Enchantments:</div></b>
+                            <div className="deckList1">{completedDecks.enchantments}</div>
+                            <p></p>
+                            <b><div className="deckList">Instants:</div></b>
+                            <div className="deckList1">{completedDecks.instants}</div>
+                            <p></p>
+                            <b><div className="deckList">Sorceries:</div></b>
+                            <div className="deckList1">{completedDecks.sorceries}</div>
+                            <p></p>
+                            <b><div className="deckList">Lands:</div></b>
+                            <div className="deckList1">{completedDecks.lands}</div>
+                            <p></p>
+                            <b><div className="deckList">Wins:</div></b>
+                            <div className="deckList">{completedDecks.wins}</div>
+                            <p></p>
+                            <b><div className="deckList">Losses:</div></b>
+                            <div className="deckList">{completedDecks.losses}</div>
+                            <p></p>
+                            <b><div className="deckList">Power Level:</div></b>
+                            <div className="deckList">{completedDecks.powerLevel}</div>
+                            <p></p>
+                            <b><div className="deckList">Primer:</div></b>
+                            <div className="deckList">{completedDecks.primer}</div>
                             </div>
                             </div>
+                            <p></p>
+                            <p></p>
+                            <p></p>
+                            <p></p>
+                            <p></p>
+                            <p></p>
+                            <p></p>
+                            <p></p>
+                            <p></p>
                         </center>
                         : <div> none </div>
                     } 

--- a/src/components/deck/decks.css
+++ b/src/components/deck/decks.css
@@ -1,0 +1,16 @@
+.deckList1 {
+    white-space: pre-line;
+    /* text-align: left; */
+    -webkit-column-count: 2;
+        -moz-column-count: 2;
+        column-count: 2;
+         
+        -webkit-column-gap: 40px;
+        -moz-column-gap: 40px;
+        column-gap: 40px; /* Specifying Column Gap */
+}
+.deckList1 {
+    white-space: pre-line;
+    /* text-align: left; */
+    
+}

--- a/src/components/nav/NavBar.js
+++ b/src/components/nav/NavBar.js
@@ -19,6 +19,9 @@ export const NavBar = () => {
                 <Link className="navbar_item" to="/MyDeckList">My Decks</Link>
             </li>
             <li className="navbar__item">
+                <Link className="navbar_item" to="/decks/new">Create New Deck</Link>
+            </li>
+            <li className="navbar__item">
                 <Link className="navbar_item" to="/info">Rules And Info</Link>
             </li>
             


### PR DESCRIPTION
Issue #3: Deck list form 

Expected: When the user clicks on the create a new deck tab on the navbar they should be routed to the deck list form, once the user completes the form and clicks the submit button the deck data should be posted to the database and the user should be routed back to the list of that user's decks 

- Added route to Application Views 
- Created DeckForm.js
- Added link to NavBar.js
- Added some css to deck.css 

Tested in postman and also in the client. When clicked the navbar tab routes to the form correctly, and when the information is input and the submit button is clicked I verified in the network tab that the post request was successful. It also routes back to the user's deck list view where the newly created deck is rendering in the list of decks