### PR TITLE
csl-DeckDetailsFunctional

### DIFF
--- a/src/components/ApplicationViews.js
+++ b/src/components/ApplicationViews.js
@@ -1,5 +1,6 @@
 import React from "react"
 import {Route} from "react-router-dom"
+import { DeckDetails } from "./deck/DeckDetails"
 import { DeckForm } from "./deck/DeckForm"
 import { DeckList } from "./deck/DeckList"
 import { MyDecks } from "./deck/MyDecks"
@@ -25,6 +26,9 @@ export const ApplicationViews = () => {
         <Route exact path="/decks/edit/:deckId(\d+)">
             <DeckForm editDeck = {true}/>
         </Route>
+        <Route exact path='/decks/:deckId(\d+)'>
+				<DeckDetails />
+			</Route>
     </main>
     </>
 }

--- a/src/components/deck/DeckDetails.js
+++ b/src/components/deck/DeckDetails.js
@@ -1,0 +1,72 @@
+import React, { useEffect, useState } from "react"
+import { Link, useParams } from "react-router-dom"
+import { getDeckById } from "./DeckManager"
+import "./decks.css"
+
+export const DeckDetails = () => {
+	const [deckDetails, setDeckDetails] = useState([])
+	const { deckId } = useParams() // Variable storing the route parameter
+    
+
+	useEffect(
+		() => {
+			getDeckById(deckId)
+				.then(setDeckDetails)
+           
+		},
+		[deckId] // Above function runs when the value of deckId changes
+	)
+
+    return (
+        //  <> Fragment puts all return elements into one JXS element 
+        <>
+
+            <div className="decks"></div>
+                            <div className="completedDeckList"><div key={`deckDetails.id-${deckDetails.id}`}>
+                            <Link to={`/decks/${deckDetails.id}`}>{deckDetails.title} </Link>
+                            <div className="deckAuthor">by {deckDetails.player?.user.username}</div> 
+                            <div className="playStyle">Play style: {deckDetails.playStyle?.label}</div>
+                            <img className="commander_image" src={deckDetails.commander} alt="commander_image" />
+                            <b><div className="deckList">Creatures:</div></b>
+                            <div className="deckList1" > {deckDetails.creatures}</div>
+                            <p></p>
+                            <b><div className="deckList">Artifacts:</div></b>
+                            <div className="deckList1">{deckDetails.artifacts}</div>
+                            <p></p>
+                            <b><div className="deckList">Enchantments:</div></b>
+                            <div className="deckList1">{deckDetails.enchantments}</div>
+                            <p></p>
+                            <b><div className="deckList">Instants:</div></b>
+                            <div className="deckList1">{deckDetails.instants}</div>
+                            <p></p>
+                            <b><div className="deckList">Sorceries:</div></b>
+                            <div className="deckList1">{deckDetails.sorceries}</div>
+                            <p></p>
+                            <b><div className="deckList">Lands:</div></b>
+                            <div className="deckList1">{deckDetails.lands}</div>
+                            <p></p>
+                            <b><div className="deckList">Wins:</div></b>
+                            <div className="deckList">{deckDetails.wins}</div>
+                            <p></p>
+                            <b><div className="deckList">Losses:</div></b>
+                            <div className="deckList">{deckDetails.losses}</div>
+                            <p></p>
+                            <b><div className="deckList">Power Level:</div></b>
+                            <div className="deckList">{deckDetails.powerLevel}</div>
+                            <p></p>
+                            <b><div className="deckList">Primer:</div></b>
+                            <div className="deckList">{deckDetails.primer}</div>
+                            </div>
+                            </div>
+                            <p></p>
+                            <p></p>
+                            <p></p>
+                            <p></p>
+                            <p></p>
+                            <p></p>
+                            <p></p>
+                            <p></p>
+                            <p></p>
+        </>
+    )
+}

--- a/src/components/deck/DeckList.js
+++ b/src/components/deck/DeckList.js
@@ -14,11 +14,7 @@ export const DeckList = () => {
 
     return (
         <>
-            <center><button className="btn btn-2 btn-sep icon-create"
-                onClick={() => {
-                    history.push({ pathname: "/decks/new" })
-                }}
-            >Create New Deck List</button></center>
+            <i><b><center><h2>Deck List Feed</h2></center></b></i>
             <article className="decks">
                 {
                     decks.map(deck => {

--- a/src/components/deck/MyDecks.js
+++ b/src/components/deck/MyDecks.js
@@ -53,30 +53,6 @@ if(isLoading) return <>Loading data...</>
                             <div className="deckAuthor">by {completedDecks.player?.user.username}</div> 
                             <div className="playStyle">Play style: {completedDecks.playStyle.label}</div>
                             <img className="commander_image" src={completedDecks.commander} alt="commander_image" />
-                            <b><div className="deckList">Creatures:</div></b>
-                            <div className="deckList1" > {completedDecks.creatures}</div>
-                            <p></p>
-                            <b><div className="deckList">Artifacts:</div></b>
-                            <div className="deckList1">{completedDecks.artifacts}</div>
-                            <p></p>
-                            <b><div className="deckList">Enchantments:</div></b>
-                            <div className="deckList1">{completedDecks.enchantments}</div>
-                            <p></p>
-                            <b><div className="deckList">Instants:</div></b>
-                            <div className="deckList1">{completedDecks.instants}</div>
-                            <p></p>
-                            <b><div className="deckList">Sorceries:</div></b>
-                            <div className="deckList1">{completedDecks.sorceries}</div>
-                            <p></p>
-                            <b><div className="deckList">Lands:</div></b>
-                            <div className="deckList1">{completedDecks.lands}</div>
-                            <p></p>
-                            <b><div className="deckList">Wins:</div></b>
-                            <div className="deckList">{completedDecks.wins}</div>
-                            <p></p>
-                            <b><div className="deckList">Losses:</div></b>
-                            <div className="deckList">{completedDecks.losses}</div>
-                            <p></p>
                             <b><div className="deckList">Power Level:</div></b>
                             <div className="deckList">{completedDecks.powerLevel}</div>
                             <p></p>


### PR DESCRIPTION
Issue: #5 Deck List Details 

Expected: When a user clicks on a deck title it should route to the deck list details page for that specific deck via id using useParams. The user should be able to see all of the components of the deck lists on the deck list model. 

Files changed:
- ApplicationViews - added route 
- DeckList.js - made some styling changes and removed the button to create a deck since it is already in the navbar 
- MyDecks.js - changed what information is rendered so that the full deck details only render on the deck details page for each specific deck 

Files created: 
DeckDetails.js