### PR TITLE
csl-eventsFullyFunctional

### DIFF
--- a/src/components/ApplicationViews.js
+++ b/src/components/ApplicationViews.js
@@ -37,6 +37,9 @@ export const ApplicationViews = () => {
         <Route exact path="/decks/edit/:deckId(\d+)">
             <DeckForm editDeck = {true}/>
         </Route>
+        <Route exact path="/events/edit/:eventId(\d+)">
+            <EventForm editEvent = {true}/>
+        </Route>
         <Route exact path='/decks/:deckId(\d+)'>
 				<DeckDetails />
 			</Route>

--- a/src/components/deck/DeckManager.js
+++ b/src/components/deck/DeckManager.js
@@ -1,9 +1,30 @@
+export const deleteDeck = (id) => {
+    return fetch(`http://localhost:8000/decks/${id}`, {
+        method: "DELETE",
+        headers: {
+            "Authorization": `Token ${localStorage.getItem("ss_token")}`
+        }
+    })
+        .then(getDecks)
+}
+
+
 export const getDecks = () => {
     return fetch("http://localhost:8000/decks", {
         headers:{
             "Authorization": `Token ${localStorage.getItem("ss_token")}`
         }
     })
+        .then(response => response.json())
+}
+export const getMyDecks = () => {
+    return fetch("http://localhost:8000/decks", {
+        headers:{
+            "Authorization": `Token ${localStorage.getItem("ss_token")}`
+        }
+    })
+        .then((getDeckByCurrentPlayer(parseInt(localStorage.getItem("playerId"))).then((deck) => {
+            return (deck.filter(deck1 => deck1["player"]["id"] === parseInt(localStorage.getItem("playerId"))))})))
         .then(response => response.json())
 }
 
@@ -51,15 +72,6 @@ export const updateDeck = (id, deck) => {
         .then(getDecks)
 }
 
-export const deleteDeck = (id) => {
-    return fetch(`http://localhost:8000/decks/${id}`, {
-        method: "DELETE",
-        headers: {
-            "Authorization": `Token ${localStorage.getItem("ss_token")}`
-        }
-    })
-        .then(getDecks)
-}
 
 export const getDeckById = (deckId) => {
 	return fetch(`http://localhost:8000/decks/${deckId}`, {

--- a/src/components/deck/MyDecks.js
+++ b/src/components/deck/MyDecks.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react"
-import { deleteDeck, getDeckByCurrentPlayer } from "./DeckManager"
+import { deleteDeck, getDeckByCurrentPlayer, getMyDecks } from "./DeckManager"
 import { Link } from "react-router-dom"
 import { getThisPlayer } from "../players/playerManager"
 import "./decks.css"
@@ -16,27 +16,17 @@ export const MyDecks = () => {
 
 
 	useEffect(() => {
-        
-		const playerId = localStorage["playerId"]
-        
-		getThisPlayer(playerId).then((player) => {
-            setIsLoading(false)
-			setCurrentPlayer(player)
-		})
-	}, [])
-
-	useEffect(() => {
 		// Query string parameter
-        if (currentPlayer.id) {
-		const playerId = currentPlayer.id
-		getDeckByCurrentPlayer(playerId).then((deck) => {
-            // setDeck(deck)
+        
+		getDeckByCurrentPlayer(parseInt(localStorage["playerId"])).then((deck) => {
             setIsLoading(false)
-			setFoundDeck(deck.filter(deck1 => deck1["player"]["id"] === parseInt(playerId)))
-		})}
+			setFoundDeck(deck)
+        })
 	}, [currentPlayer])
 	
 if(isLoading) return <>Loading data...</>
+
+
 
     return (
         //  <> Fragment puts all return elements into one JXS element 
@@ -62,9 +52,9 @@ if(isLoading) return <>Loading data...</>
                             <button type="button" className="button" onClick={() => {
                                let text
                                if (window.confirm("Are you sure you want to delete this deck?") === true) {
-                                   deleteDeck(completedDecks.id).then(() => history.push("/deckfeed"));}
+                                   deleteDeck(completedDecks.id).then(() => getDeckByCurrentPlayer(parseInt(localStorage.getItem("playerId"))).then(setFoundDeck));}
                                    else {text = "You canceled!"}
-                                   
+                                
                                }}>Delete</button>
                             <button type="button" className="button" onClick={() => {
                                 history.push(`/decks/edit/${completedDecks.id}`)}

--- a/src/components/events/EventForm.js
+++ b/src/components/events/EventForm.js
@@ -15,7 +15,8 @@ export const EventForm = ({ editEvent }) => {
         time: "",
         venue: "",
         address: "",
-        description: ""
+        description: "",
+        organizer: ""
     })
 
 
@@ -28,7 +29,8 @@ export const EventForm = ({ editEvent }) => {
                     time: res.time,
                     venue: res.venue,
                     address: res.address,
-                    description: res.description
+                    description: res.description,
+                    organizer: res.organizer
                 }
                 setCurrentEvent(eventEdit)
             })
@@ -142,7 +144,8 @@ export const EventForm = ({ editEvent }) => {
                         time: currentEvent.time,
                         venue: currentEvent.venue,
                         address: currentEvent.address,
-                        description: currentEvent.description
+                        description: currentEvent.description,
+                        organizer: localStorage.getItem("playerId")
                     }
                     editEvent
                         ? updateEvent(eventId, event)

--- a/src/components/events/EventList.js
+++ b/src/components/events/EventList.js
@@ -1,35 +1,86 @@
 import React, { useState, useEffect } from "react"
 import { useHistory } from "react-router-dom/cjs/react-router-dom.min"
-import { getEvents } from "./EventManager"
+import { deleteEvent, getEvents, joinEvent, leaveEvent } from "./EventManager"
 
 
 export const EventList = () => {
     const [events, setEvents] = useState([])
+    // const [attendees, setAttendees] = useState([])
     const history = useHistory()
     useEffect(() => {
         getEvents().then(data => setEvents(data))
     }, [])
 
+    // let attendees = events.attendees?.user.id
+    //     useEffect(() => {
+    //     getEvents().then(data => setEvents(data))
+        
+    //     }, [attendees])
+
+    function refreshPage() {
+        window.location.reload(false);
+      }
+
     return (
         <>
             <i><b><center><h2>Events</h2></center></b></i>
-                <center><button type="button" className="btt" onClick={() => {
-                    history.push(`/events/newEvent`)}
-                }>Create New Event</button></center>
+            <center><button type="button" className="btt" onClick={() => {
+                history.push(`/events/newEvent`)
+            }
+            }>Create New Event</button></center>
             <article className="events">
                 {
                     events.map(event => {
                         return <section key={`event--${event.id}`} className="event">
                             <ol>
-                            <div className="event">{event.name}</div>
-                            <div className="event">Address: {event.address}</div>
-                            <div className="event">Date: {event.date}</div>
-                            <div className="event">Time: {event.time}</div>
-                            <div className="event">Description: {event.description}</div>
-                            <p></p>
-                            <p></p>
-                            <p></p>
-                            <p></p>
+                                <div className="event">{event.name}</div>
+                                <div className="event">Address: {event.address}</div>
+                                <div className="event">Date: {event.date}</div>
+                                <div className="event">Time: {event.time}</div>
+                                <div className="event">Description: {event.description}</div>
+                                <div className="event">Organizer: {event.organizer?.user.username}</div>
+                                <div className="event">Attendees: </div>
+                                <div>{
+                                    event.attendees?.map((player) => {
+                                        return(
+                                            <div key={player.user.id}>
+                                                {player.user?.username}
+                                                </div>
+                                        )
+                                    }
+                                    )
+                                }
+
+                                </div>
+                                {event.organizer?.id === parseInt(localStorage.getItem("playerId")) ?
+                                    <button onClick={() => history.push(`/events/edit/${event.id}`)}>Edit</button>
+                                    : ""}
+                                {event.organizer?.id === parseInt(localStorage.getItem("playerId")) ?
+                                    <button onClick={() => { deleteEvent(event.id).then(setEvents) }}>Delete</button>
+                                    : ""}
+                                {
+                                    event.joined
+                                        ?
+                                        // Leave button
+                                        <button onClick={() => {
+                                            leaveEvent(event.id).then((window.confirm("Are you sure you want to cancel your RSVP?")? refreshPage() : "")
+                                            // .then(refreshPage())
+                                            )}}>
+                                            Leave Event
+                                        </button>
+                                        :
+                                        // join button
+                                        <button onClick={() => {
+                                            joinEvent(event.id).then((window.confirm("Are you sure you want to RSVP?")? refreshPage() : "")
+                                            // .then(refreshPage())
+                                            )}}>
+                                            Join Event
+                                        </button>
+                                }
+                                <p></p>
+                                <p></p>
+                                <p></p>
+                                <p></p>
                             </ol>
                         </section>
                     })

--- a/src/components/events/EventManager.js
+++ b/src/components/events/EventManager.js
@@ -60,3 +60,21 @@ export const updateEvent = (id, event) => {
     })
         .then(getEvents)
 }
+export const joinEvent = (eventId) => {
+    return fetch(`http://localhost:8000/events/${eventId}/signup`, {
+      method: "POST",
+      headers: {
+        "Authorization": `Token ${localStorage.getItem("ss_token")}`,
+      },
+    }).then(res => res.json())
+  }
+  
+  export const leaveEvent = (eventId) => {
+    return fetch(`http://localhost:8000/events/${eventId}/leave`, {
+      method: "Delete",
+      headers: {
+        "Authorization": `Token ${localStorage.getItem("ss_token")}`,
+      },
+    })
+  }
+  


### PR DESCRIPTION
Issue #7 #12, #13, #14 (Fixed a re-rendering issue with the deck delete function and finished Event CRUD)

Expected: When a user clicks the delete button on the MyDecks page it should show the updated deck list, when the user goes to the events page they should see a join button and when clicked it should trigger a window alert then the button should change from join to leave, vice versa should happen when they click the leave event button, Users should also see the event organizers name and a list of the current attendees of that event 

Modified:
ApplicationViews to add a route to the EventForm
DeckManager 
MyDecks: took the filtering out of the front end because it was causing issues and it is now being filtered on the server side which cleaned up the code and is now working without any issues after deleting a deck
EventList: now rendering the organizer of the event and also the attendees of the event, as well as, a window alert when a user clicks the join or leave button which triggers a page reload where the proper text on the buttons is rendered (if a user has currently joined an event then it renders the leave button and vice versa)
